### PR TITLE
Remove "Web" from Initial Caps section

### DIFF
--- a/guides/idl2/idlv2-authoring-guide-and-best-practice.md
+++ b/guides/idl2/idlv2-authoring-guide-and-best-practice.md
@@ -1189,9 +1189,6 @@ Initial caps mean capitalizing the first letter of a word. Use initial caps for:
 
 -   Proper names (the Insert menu)
 
--   “Web” when referring to the World Wide Web and to a corporate Web
-    (intranet)
-
 -   “Wizard” when used as part of a proper name of a wizard (for
     example, the Answer Wizard)
 


### PR DESCRIPTION
Web is no longer capitalized according to the Microsoft Style Guide: https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/w/web-world-wide-web-www