### PR TITLE
Add reminder to configure lab instance DNS

### DIFF
--- a/lod/access-control-lists.md
+++ b/lod/access-control-lists.md
@@ -51,6 +51,8 @@ This configuration would block the VM from accessing learnondemandsystems.com, b
 
 Access Control lists are assigned to a lab profile, on the Networks tab. Custom Access Control lists are only available with **Web Access (NAT)** network types.
 
+**Before you assign an access control list, VMs in the lab environment must be configured to pull DNS from the lab gateway, otherwise there may be false positive blocks. If using a DNS server inside the lab, it should have the gateway address assigned as the primary forwarder.**
+
 1. Navigate to the lab profile you wish to configure an ACL on. 
 
 1. Click **Edit** in the upper-right, to edit the lab profile. 


### PR DESCRIPTION
SquidGuard requires everything it's sniffing get DNS from the PFSense VM. Adding a statement that addresses this.

<!--
# Learn on Demand Systems documentation pull request guidance

Thanks for submitting a pull request to the Learn on Demand Systems technical documentation repository. 

Unless the change is trivial (e.g. correcting a typo), please include a comment describing why you are proposing these documentation changes.

You can remove this comment once you have read and understood it.

Thank you!
-->
