### PR TITLE
Corrected Spelling/Change to section formating

### DIFF
--- a/guides/idl2/idl2-cheat-sheet.md
+++ b/guides/idl2/idl2-cheat-sheet.md
@@ -57,9 +57,7 @@
 | Copyable and Type Text         | `++++Copyable and Type text++++`|
 | Replacement Token | `click the @ lab toolbar button ` |
 | Embed YouTube video | `!video[text to display](url)` (URLs from YouTube.com auto embed)               |
-| Sections |`:::sectionName(variableName-variabelValue)`
-|| `section text or markdown elements`
-||`:::`
+| Sections |`:::sectionName(variableName=variableValue)`<br>`section text or markdown elements`<br>`:::`
 |<BR> | |
 
 ---


### PR DESCRIPTION
typo fix
changed - to = in section formatting example to avoid confusion
put copyable text on one line

<!--
# Learn on Demand Systems documentation pull request guidance

Thanks for submitting a pull request to the Learn on Demand Systems technical documentation repository. 

Unless the change is trivial (e.g. correcting a typo), please include a comment describing why you are proposing these documentation changes.

You can remove this comment once you have read and understood it.

Thank you!
-->
