### PR TITLE
Images still say Learn on Demand Systems

### DIFF
--- a/lod/container-registries.md
+++ b/lod/container-registries.md
@@ -18,7 +18,7 @@ When persisting changes to a container image, you can choose to save the changes
 
 1. Populate the following fields:
 
-    ![](images/create-container-registry.png)
+    ![](NEEDS NEW IMAGE)
 
     - **Name**: Enter the name of the container registry. This will be the display  name in LOD. 
 
@@ -46,7 +46,7 @@ When you are persisting changes in a container lab, you can persist changes to a
 
 1. From container registry details page, click **Add Account**
 
-    ![](images/container-registry-account.png)
+    ![](NEEDS A NEW IMAGE)
 
 1. Enter the **username** used to log in to the registry account. 
 


### PR DESCRIPTION
I got the first screenshot but I think the second one might have had a few platform changes
![image](https://user-images.githubusercontent.com/62734074/144931512-ca37cf94-5a04-417e-ae55-003427c8103f.png)

<!--
# Skillable documentation pull request guidance

Thanks for submitting a pull request to the Skillable technical documentation repository. 

Unless the change is trivial (e.g. correcting a typo), please include a comment describing why you are proposing these documentation changes.

You can remove this comment once you have read and understood it.

Thank you!
-->
