### PR TITLE
added new docs for new api commands

### DIFF
--- a/lod/lod-api/lod-api-class.md
+++ b/lod/lod-api/lod-api-class.md
@@ -2,6 +2,7 @@
 
 The **Class** command returns information about a class.
 
+> [!alert] This is now deprecated
 ## Parameters
 
 |Name|Type|Required|Note
@@ -18,7 +19,7 @@ The **Class** command returns information about a class.
 |End|Long|No|When the class ends (in Unix epoch time)|
 |Expires|Long|No|When labs can no longer be associated with the class (in Unix epoch time)|
 |Instructor|Instructor|Yes|The class instructor. See the Instructor Type below.|
-|URL|String|No|A URL where the class can be viewed|
+|URL|String|No|This response property is deprecated. Unless explicitly allowed by Skillable, this field will always be null. To obtain a class URL, use the [ClassAccessUrl API](/lod-api-classaccessurl.md). |
 |Error|String|Yes|In the event of an error, this will contain a detailed error message.|
 
 ## Instructor
@@ -47,7 +48,7 @@ https://labondemand.com/api/v3/class/?id=4449999
     "Expires": 1335978000,
     "InstructorFirstName": "Demo",
     "InstructorLastName": "Instructor",
-    "Url": https://labondemand.com/class/5bbca218-2cbe-47ab-bd37-bd9b5b623dea,
+    "Url": null,
     "Status": 1,
     "Error": null
 }

--- a/lod/lod-api/lod-api-class.md
+++ b/lod/lod-api/lod-api-class.md
@@ -2,7 +2,6 @@
 
 The **Class** command returns information about a class.
 
-> [!alert] This is now deprecated
 ## Parameters
 
 |Name|Type|Required|Note

--- a/lod/lod-api/lod-api-classaccessurl.md
+++ b/lod/lod-api/lod-api-classaccessurl.md
@@ -1,0 +1,37 @@
+# ClassAccessUrl
+
+The **ClassAccessUrl** command returns a single use URL to access a class. 
+
+## Parameters
+
+|Name|Type|Required|Note|
+|--- |--- |--- |--- |
+|Id|String|Yes|The unique identifier of the class, as represented in your organization.
+
+## Response 
+
+|Property|Type|Nullable|Note|
+|--- |--- |--- |--- |
+|URL|String||The URL 
+|Result|Int|False|0 = Error
+||||1 = Success|
+|Error|String|True|In the event of an error, this will contain a detailed error message.|
+
+## Example Usage
+
+Imagine… A user is running a lab instance with an ID = 2393048
+
+```
+https://labondemand.com/api/v3/ClassAccessUrl/?id=1234567 
+```
+
+## Example Response
+```linenums
+{
+
+"Url": "https://labondemand.com/class/access/ab1c2345-6d7b-890e-f1gh-234ij5kl6m7n",    
+"Error": null,    
+"Status": 1
+
+}
+```

--- a/lod/lod-api/lod-api-details.md
+++ b/lod/lod-api/lod-api-details.md
@@ -104,7 +104,7 @@ The **Details** command retrieves detailed information about a specified lab ins
 |NumTasks|Integer|No|If the lab has content (HasContent=true), indicates the total number of tasks in the lab.|
 |NumCompletedTasks|Integer|No|If the lab has content (HasContent=true), indicates the number of tasks the student has completed.|
 |TaskCompletePercent|Integer|No|If the lab has content (HasContent=true), indicates the percentage of tasks that the student has completed.|
-|MonitorUrl|String|Yes|If the lab is currently running, a URL at which the lab can be monitored in real time.|
+|MonitorUrl|String|Yes|This response property is deprecated. Unless explicitly allowed by Skillable, this field will always be null. To obtain an access URL, use the [Launch command](/lod-api-launch.md) or the [ClassAccessUrl command](/lod-api-classaccessurl.md).
 |DetailsUrl|String|No|The URL at which the lab instance details can be reviewed (required authentication to view)|
 |Errors|Array of String|No|An array of all errors associated with the lab instance.|
 |IpAddress|String|Yes|The user's IP address. This is only included if the IP address was provided when the lab was launched.|
@@ -120,7 +120,7 @@ The **Details** command retrieves detailed information about a specified lab ins
 |CloudCredentials|Array|Yes|An array of credentials assigned to the lab instance. See the CloudCredentials Type below.|
 |CloudPortalCredentials|Array|Yes|An array of credentials assigned to the lab instance. See the CloudPortalCredentials Type below. |
 |VirtualMachineCredentials|Array|Yes|An array of credentials used to access the virtual machines. See the VirtualMachineCredentials Type below. |
-|ClientUrl|String|No|The URL at which a student may access their lab instance.|
+|ClientUrl|String|No|This response property is deprecated. Unless explicitly allowed by Skillable, this field will always be null. To obtain an access URL, use the [Launch command](/lod-api-launch.md) or the [ClassAccessUrl command](/lod-api-classaccessurl.md).|
 |ActivityResults|Array of ActivityResults|Yes|An array of results for activities displayed in the lab instance. See the ActivityResults Type below.|
 |ActivityGroupResults|Array of ActivityGroupResults|Yes|An array of results for activity groups displayed in the lab instance. See the ActivityResults Type below.|
 |EstimatedReadySeconds|Integer|No|An estimated number of seconds before the lab is ready.|
@@ -314,7 +314,7 @@ https://labondemand.com/api/v3/details?labinstanceid=360701
         }
     ],
     "CloudPlatformId": 10,
-    "ClientUrl": "https://labclient.labondemand.com/Setup/a37e1990-e7c8-4fc9-9512-a0d2418bc0a3",
+    "ClientUrl": null,
     "ActivityResults": [
         {
             "ActivityId": 4910,

--- a/lod/lod-api/lod-api-get-or-create-class.md
+++ b/lod/lod-api/lod-api-get-or-create-class.md
@@ -28,7 +28,7 @@ The **GetOrCreateClass** command returns information about a class. If the class
 |End|Long|No|When the class ends (in Unix epoch time)|
 |Expires|Long|No|When labs can no longer be associated with the class (in Unix epoch time)|
 |Instructor|Instructor|Yes|The class instructor. See the Instructor Type below.|
-|URL|String|No|A URL where the class can be viewed, including real-time monitoring of labs launched within it.|
+|URL|String|No|This response property is deprecated. Unless explicitly allowed by Skillable, this field will always be null. To obtain a class URL, use the [ClassAccessUrl API](/lod-api-classaccessurl.md).|
 |maxActiveLabInstances|Integer|Yes|The maximum number of active lab instances than can exist concurrently within this class context.|
 |availableLabs|Integer Array|Yes|The IDs of labs available for launch within the class when using the class attendance UI directly in Lab on Demand (generally not used for class deliveries managed outside of Lab on Demand).
 
@@ -67,7 +67,7 @@ https://labondemand.com/api/v3/GetOrCreateClass/?id=4449999&name=Sample+Class&in
     "Expires": 1335978000,
     "InstructorFirstName": "Demo",
     "InstructorLastName": "Instructor",
-    "Url": https://labondemand.com/class/5bbca218-2cbe-47ab-bd37-bd9b5b623dea,
+    "Url": null,
     "MaxActiveLabInstances": null,
     "AvailableLabs":[],
     "Status": 1,

--- a/lod/lod-api/lod-api-lab-access-url.md
+++ b/lod/lod-api/lod-api-lab-access-url.md
@@ -1,0 +1,36 @@
+# LabAccessUrl
+
+The **LabAccessUrl** command returns a single use URL to access a lab instance.
+
+## Parameters
+
+|Name|Type|Required|Note|
+|--- |--- |--- |--- |
+|labInstanceId|Long|Yes|The unique identifier of the class, as represented in your organization.
+|roleId|Integer|No|Allows you specify the role(s) to assign to the user. You may pass multiple instances of this parameter to specify multiple roles. Roles are used for specialized integration purposes and are not needed in typical integration scenarios. Role IDs will be provided by Skillable when appropriate.|
+
+## Response 
+
+|Property|Type|Nullable|Note|
+|--- |--- |--- |--- |
+|URL|String||The URL 
+|Result|Int|False|0 = Error
+||||1 = Success|
+|Error|String|True|In the event of an error, this will contain a detailed error message.|
+
+## Example Usage
+
+Imagine… You have a class within your system with an ID = 4449999 that already exists in Lab on Demand.
+
+```
+https://labondemand.com/api/v3/LabAccessUrl?LabInstanceId=4449999
+```
+
+## Example Response
+```linenums
+{
+    "Url": "https://labondemand.com/access/ab1c2345-6d7b-890e-f1gh-234ij5kl6m7n",
+    "Error": null,
+    "Status": 1
+}
+```

--- a/lod/lod-api/lod-api-lab-monitor-url.md
+++ b/lod/lod-api/lod-api-lab-monitor-url.md
@@ -1,0 +1,35 @@
+# LabMonitorUrl
+
+The **LabMonitorUrl** command returns a single use URL to monitor a lab instance. 
+
+## Parameters
+
+|Name|Type|Required|Note|
+|--- |--- |--- |--- |
+|labInstanceId|Long|Yes|The unique identifier of the class, as represented in your organization.
+
+## Response 
+
+|Property|Type|Nullable|Note|
+|--- |--- |--- |--- |
+|URL|String||The URL 
+|Result|Int|False|0 = Error
+||||1 = Success|
+|Error|String|True|In the event of an error, this will contain a detailed error message.|
+
+## Example Usage
+
+Imagine… You have a class within your system with an ID = 4449999 that already exists in Lab on Demand.
+
+```
+https://labondemand.com/api/v3/LabMonitorUrl?LabInstanceId=4449999
+```
+
+## Example Response
+```linenums
+{
+    "Url": "https://labondemand.com/access/ab1c2345-6d7b-890e-f1gh-234ij5kl6m7n?monitor=1",
+    "Error": null,
+    "Status": 1
+}
+```

--- a/lod/lod-api/lod-api-main.md
+++ b/lod/lod-api/lod-api-main.md
@@ -56,6 +56,7 @@ Alternatively, you may review the Lab on Demand Postman Collection (2.1) of call
 - [Cancel](lod-api-cancel.md) - Cancels a specified lab instance.
 - [Catalog](lod-api-catalog.md) - Returns all lab series, lab profiles, and delivery regions available to your organization.
 - [Class](lod-api-class.md) - Returns information about a class.
+- [ClassAccessUrl](lod-api-classaccessurl.md) - Returns a single use URL to access a class.
 - [CloseUserAccount](lod-api-close-user-account.md) - Allows an API consumer to close a user account created within the system removing all identifying information.
 - [DeleteClass](lod-api-delete-class.md) - Deletes a specified class.
 - [DeliveryRegions](lod-api-delivery-regions.md) - Returns all delivery regions available to your organization.
@@ -65,6 +66,8 @@ Alternatively, you may review the Lab on Demand Postman Collection (2.1) of call
 - [GetLabInstructions](lod-api-get-lab-instructions.md) - Returns instructions for a specific lab.
 - [GetLabInstructionsPackage](lod-api-get-lab-instructions-package.md) - Returns the contents of the instructions for a specific lab as a file archive.
 - [GetOrCreateClass](lod-api-get-or-create-class.md) - Returns information about a class. If the class doesn’t exist, it is created.
+- [LabAccessUrl](/lod-api-lab-access-url.md) - Returns a single use URL is used to access a lab instance.
+- [LabMonitorUrl](/lod-api-lab-monitor-url.md) - Returns a single use URL to monitor a lab instance. 
 - [LabProfile](lod-api-lab-profile.md) - Retrieves information about a specified lab profile.
 - [LatestResults](lod-api-latest-results.md) - Returns information about all lab instance results that have recently started or ended.
 - [Launch](lod-api-launch.md) - Launches a specified lab for a specified user.

--- a/lod/lod-api/lod-api-user-running-and-saved-labs.md
+++ b/lod/lod-api/lod-api-user-running-and-saved-labs.md
@@ -24,7 +24,7 @@ The **UserRunningAndSavedLabs** command retrieves all labs that are currently ru
 |LabProfileNumber|String|No|The number/code of the lab profile the lab instance is based on|
 |Start|Long|No|When the lab instance was started (in Unix epoch time)|
 |Expires|Long|No|When the lab will expire (in Unix epoch time)|
-|URL|String|No|A URL where the lab can be viewed by the user|
+|URL|String|No|This response property is deprecated. Unless explicitly allowed by Skillable, this field will always be null. To obtain an access URL, use the [Launch command](/lod-api-launch.md) or the [ClassAccessUrl command](/lod-api-classaccessurl.md).|
 |IsExam|Boolean|No|Indicates whether the lab is considered a scorable exam|
 
 ## SavedLab
@@ -62,7 +62,7 @@ https://labondemand.com/api/v3/userrunningandsavedlabs?userid=555
             "LabProfileNumber": "LAB001",
             "Start": 1338223121,
             "Expires": 1338244721,
-            "Url": https://labondemand.com/console/setup/7fdf8e48-6d66-435d-8069-04e540db9b74,
+            "Url": null,
             "IsExam": false,
         }
     ],


### PR DESCRIPTION
Add docs for:
- ClassAccessUrl
- LabMonitorUrl
- LabAccessUrl

Updated other API docs with deprecation notes for deprecated URL fields.

<!--
# Skillable documentation pull request guidance

Thanks for submitting a pull request to the Skillable technical documentation repository. 

Unless the change is trivial (e.g. correcting a typo), please include a comment describing why you are proposing these documentation changes.

You can remove this comment once you have read and understood it.

Thank you!
-->
