### PR TITLE
Changing vSphere to ESX

### DIFF
--- a/tms/connectivity-requires.md
+++ b/tms/connectivity-requires.md
@@ -109,7 +109,7 @@ A CSV containing these ranges is available for use in automating any whitelist c
 
 ## Browser Support
 
-The majority of VM or container based labs can be accessed via HTML5 websocket controllers. vSphere, Hyper-V, and Docker<sup>1</sup> labs all utilize this technology. Some labs may require an alternate Enhanced controller available only for Internet Explorer which requires installation of a plugin.
+The majority of VM or container based labs can be accessed via HTML5 websocket controllers. ESX, Hyper-V, and Docker<sup>1</sup> labs all utilize this technology. Some labs may require an alternate Enhanced controller available only for Internet Explorer which requires installation of a plugin.
 
 <sup>1</sup> Docker labs that expose an external service port do so over ports 41952-65534. Connection requirements are dependent on the exposed service.
 


### PR DESCRIPTION
Dillon, not certain if this must be changed or not, but I believe we were removing references to vSphere now. Up to you whether it stays or goes here.

<!--
# Skillable documentation pull request guidance

Thanks for submitting a pull request to the Skillable technical documentation repository. 

Unless the change is trivial (e.g. correcting a typo), please include a comment describing why you are proposing these documentation changes.

You can remove this comment once you have read and understood it.

Thank you!
-->
