### PR TITLE
Audited IPs in document

### DIFF
--- a/tms/connectivity-requires.md
+++ b/tms/connectivity-requires.md
@@ -55,6 +55,7 @@ For those that need to create a firewall exception rule to allow connectivity to
   - 185.254.59.0/24
   - 103.18.85.0/24
   - 163.47.101.0/25
+  - 168.245.203.241 - 168.245.203.254
 
 Certain lab environments utilize GitHub; therefore, the following URL should be excepted: ```https://githubusercontent.com```
 
@@ -102,7 +103,7 @@ Software that communicates with remote servers outside of the lab environment ma
 
 The below ranges are used by Public IP internet access labs.
 
-185.254.59.40 - 185.254.59.255, 185.254.58.0/24 185.254.57.0/24 168.245.200.0/23 168.245.202.0/23 128.136.160.9 - 128.136.160.254 103.18.85.21 - 103.18.85.254 199.101.110.31 - 199.101.110.254 199.101.111.05 - 199.101.111.254, 199.101.108.5 - 199.101.109.254, 103.8.28.0/24, 103.177.46.0/25
+185.254.59.40 - 185.254.59.255, 185.254.58.0/24 185.254.57.0/24 168.245.200.0/23 168.245.202.0/23 128.136.160.9 - 128.136.160.254 103.18.85.21 - 103.18.85.254  199.101.111.05 - 199.101.111.254, 199.101.108.5 - 199.101.109.254, 103.8.28.0/24, 103.177.46.0/25, 206.196.30.15 - 206.196.30.252
 
 
 A CSV containing these ranges is available for use in automating any whitelist changes. It can be found [here](lods-whitelist-ips.csv).


### PR DESCRIPTION
    IP Ranges: 
	199.101.111.220 - 199.101.111.239, 		TPA WebNet Outbound NAT
	163.47.101.118 - 163.47.101.126, 		SEA WebNet NAT Range
	185.254.59.118 - 185.254.59.127, 		EU WebNet/SecureNet NAT
	103.18.85.29 - 103.18.85.30, 			AU WebNet SecureNet NAT
	103.18.87.240 - 103.18.87.249			SGP WebNet Outbound NAT
	
	168.245.203.241 - 168.245.203.254		ASH MISSING Web/SecNet Range ADDED to MD


185.254.59.40 - 185.254.59.255, 	EU** (really its top half of /25 but this is fine)
185.254.58.0/24 		EU**
185.254.57.0/24 		EU**
168.245.200.0/23 		SEA**
168.245.202.0/23 		ASH**
128.136.160.9 - 128.136.160.254 	TPA**
103.18.85.21 - 103.18.85.254 		AU**
199.101.110.31 - 199.101.110.254 		Check to see if this went to ASH, confirmed, infra ips now, should be removed, REMOVED from MD
199.101.111.05 - 199.101.111.254, 	TPA**
199.101.108.5 - 199.101.109.254, 	SEA**
103.8.28.0/24, 		EU**
103.177.46.0/25		SGP**
TPA 206.196.30.15 - 206.196.30.252		MISSING //// ADDED to MD

<!--
# Skillable documentation pull request guidance

Thanks for submitting a pull request to the Skillable technical documentation repository. 

Unless the change is trivial (e.g. correcting a typo), please include a comment describing why you are proposing these documentation changes.

You can remove this comment once you have read and understood it.

Thank you!
-->
