### PR TITLE
Old LOD short link

### DIFF
--- a/tms/tms-administrators/classes/training-keys/class-training-keys.md
+++ b/tms/tms-administrators/classes/training-keys/class-training-keys.md
@@ -14,7 +14,7 @@ Two types of training keys are available to directly enroll students into a clas
 
 For either key, an administrator creates a class and generates the enrollment keys or the event key (see Figure 1 below for the administrator to user flow). All training keys allow users to self-register by creating a user account and provisioning their training. Existing users can login and redeem their key to open their training. 
 
-Some setup by our help desk is needed to enable the ability for students to create user accounts from your login page. Please submit a Support ticket at [**https://lod.one/help**](https://lod.one/help) for information.
+Some setup by our help desk is needed to enable the ability for students to create user accounts from your login page. Please submit a Support ticket at [**https://lod.one/help**](https://lod.one/help)  for information.
 
 
 ![](/tms/images/class-training-keys.png)


### PR DESCRIPTION
This may not be an issue at all but I was wondering if [**https://lod.one/help**](https://lod.one/help) should be changed to a Skillable short link? I just added a space at the end of the link at line 17 to tag it's place.

<!--
# Skillable documentation pull request guidance

Thanks for submitting a pull request to the Skillable technical documentation repository. 

Unless the change is trivial (e.g. correcting a typo), please include a comment describing why you are proposing these documentation changes.

You can remove this comment once you have read and understood it.

Thank you!
-->
