### PR TITLE
Create trigger-security-review-when-save-or-auto-save-are-enabled-on-…

### DIFF
--- a/lod/home-landing-pages/a-z-index.md
+++ b/lod/home-landing-pages/a-z-index.md
@@ -466,6 +466,10 @@
         <div class="subtopic_title">Themes</div>
         <div class="subtopic_description">Create themes to customize the look and feel of labs using CSS, and JavaScript.</div>
       </a>
+      <a class="subtopic_link" href="/trigger-security-review-when-save-or-auto-save-are-enabled-on-a-cloud-slice-lab.md">
+        <div class="subtopic_title">Trigger Security Review for Save and Auto-save Features</div>
+        <div class="subtopic_description">Allows lab authors to have a security review automatically triggered when enabling the save or auto-save features in a cloud slice lab profile.</div>
+      </a>
       <a class="subtopic_link" href="/lod/variable-display.md">
         <div class="subtopic_title">Variable Display for Lab Instructions</div>
         <div class="subtopic_description">Variably display lab instructions and lab instructions elements based on lab variables.</div>

--- a/lod/home-landing-pages/cloud-slice-development-landing.md
+++ b/lod/home-landing-pages/cloud-slice-development-landing.md
@@ -164,6 +164,10 @@
         <div class="subtopic_title">Create a Cloud Subscription Pool</div>
         <div class="subtopic_description">Create a Cloud Subscription Pool to load balance labs across your cloud subscriptions.</div>
       </a>
+      <a class="subtopic_link" href="/trigger-security-review-when-save-or-auto-save-are-enabled-on-a-cloud-slice-lab.md">
+        <div class="subtopic_title">Trigger Security Review for Save and Auto-save Features</div>
+        <div class="subtopic_description">Allows lab authors to have a security review automatically triggered when enabling the save or auto-save features in a cloud slice lab profile.</div>
+      </a>
     </div>
   </div>
   <div class="subtopic">

--- a/lod/trigger-security-review-when-save-or-auto-save-are-enabled-on-a-cloud-slice-lab.md
+++ b/lod/trigger-security-review-when-save-or-auto-save-are-enabled-on-a-cloud-slice-lab.md
@@ -1,0 +1,55 @@
+---
+title: "Trigger Security Review for Save and Auto-save Features"
+description: "Allows lab authors to have a security review automatically triggered when enabling the save or auto-save features in a cloud slice lab profile."
+isPublished: true
+---
+
+# Trigger Security Review for Save and Auto-save Features
+
+This feature allows lab authors to have a security review automatically triggered when enabling the save or auto-save features in a cloud slice lab profile. This documentation will guide you through the usage and benefits of this feature.
+
+## Table of Contents
+
+[Overview](#overview)
+
+[Security Review Trigger](#security-review-trigger)
+
+[Benefits](#benefits)
+
+[Regression Testing on Temporary Approvals](#regression-testing-on-temporary-approvals)
+
+[Conclusion](#conclusion)
+
+## Overview
+
+As a lab author, you can now enable the save or auto-save feature in your cloud slice lab profile. By doing so, a security review process will be automatically triggered. This review is conducted to evaluate the cloud resource costs and determine the necessity of the save features for your lab. This ensures that labs are optimized for cost-efficiency and resource utilization.
+
+## Enabling Save or Auto-save Feature
+
+When creating or editing a cloud slice lab profile, you will find options to enable the save and auto-save features. By enabling either of these features, you indicate your preference to have the lab content saved automatically or manually by users.
+
+## Security Review Trigger
+
+Once you enable the save or auto-save feature, a security review will be automatically triggered. The purpose of this review is to assess the following aspects:
+
+1.  Cloud Resource Costs: The review will evaluate the potential impact on cloud resource costs, considering factors such as storage, compute, and data transfer. It ensures that the save and auto-save features do not incur unnecessary expenses.
+
+1.  Necessity for Save Features: The review will determine the necessity of the save features for your lab. It ensures that the save and auto-save functionalities align with the intended learning objectives and user requirements.
+
+## Benefits
+
+By triggering a security review for save and auto-save features, the following benefits are achieved:
+
+1.  Cost Optimization: The review helps identify any potential cost implications associated with saving lab content. It ensures that unnecessary cloud resource consumption is minimized, promoting cost optimization.
+
+1.  Resource Utilization: The review ensures that the save and auto-save features are justified in terms of their contribution to the learning experience. It helps maintain efficient resource utilization within the lab environment.
+
+## Regression Testing on Temporary Approvals
+
+If temporary approvals have been granted for specific labs, it is essential to perform regression testing. This ensures that the temporary approvals are still functioning correctly and do not interfere with the security review process triggered by enabling save or auto-save features.
+
+## Conclusion
+
+With the Trigger Security Review for Save and Auto-save Features in Cloud Slice Labs feature, lab authors can ensure that the use of save and auto-save functionalities is reviewed for cost efficiency and necessity. Enable the save or auto-save feature in your cloud slice lab profile to initiate the security review process.
+
+If you have any further questions or need assistance, please reach out to our support team. Happy lab authoring!


### PR DESCRIPTION
…a-cloud-slice-lab.md

Added a new file: Allows lab authors to have a security review automatically triggered when enabling the save or auto-save features in a cloud slice lab profile.

<!--
# Skillable documentation pull request guidance

Thanks for submitting a pull request to the Skillable technical documentation repository. 

Unless the change is trivial (e.g. correcting a typo), please include a comment describing why you are proposing these documentation changes.

You can remove this comment once you have read and understood it.

Thank you!
-->
